### PR TITLE
Fix: decimal.TryParse is now Culture-Invariant

### DIFF
--- a/Time_Shift/Util/Expression.cs
+++ b/Time_Shift/Util/Expression.cs
@@ -247,7 +247,7 @@ namespace ChapterTool.Util
             var variable = varRet.ToString();
             if (IsDigit(varRet[0]))
             {
-                if (!decimal.TryParse(variable, out decimal number))
+                if (!decimal.TryParse(variable, NumberStyles.Number, CultureInfo.InvariantCulture, out decimal number))
                     throw new Exception($"Invalid number token [{variable}]");
                 return new Token(number) { Value = variable };
             }


### PR DESCRIPTION
In my default regional settings decimal has comma separator, not dot. Therefore, I was getting such errors while using expressions:
![image](https://github.com/tautcony/ChapterTool/assets/46827461/54fd263c-c0ff-4b6f-88ac-2f073b688fb0)

Using InvariantCulture allows code to ignore this issue and parse decimal with dot every time.